### PR TITLE
Fix memory leak in rtl_tcp on TCP client close

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -131,6 +131,7 @@ add_executable(rtl_biast rtl_biast.c)
 add_executable(rtl_raw2wav    rtl_raw2wav.c     convenience/convenience.c  convenience/wavewrite.c)
 add_executable(rtl_wavestat   rtl_wavestat.c    convenience/convenience.c  convenience/waveread.c)
 add_executable(rtl_wavestream rtl_wavestream.c  convenience/convenience.c  convenience/waveread.c)
+set_property(TARGET rtl_tcp PROPERTY C_STANDARD 11)
 
 if (WITH_RPC)
     add_executable(rtl_rpcd rtl_rpcd.c rtlsdr_rpc_msg.c)


### PR DESCRIPTION
This changeset fixes two issues I observed in `rtl_tcp`:
1.  fix a memory leak that occurs when a client disconnects from the server.
2. refines the shutdown code by clarifying the behavior around `do_exit` and introducing a new `conn_reset` boolean.

To facilitate the latter change, this binary requires C11 to allow the use of atomic types.